### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,5 +4,5 @@ begin	KEYWORD2
 home	KEYWORD2
 moveTo	KEYWORD2
 move	KEYWORD2
-getHome KEYWORD2
-getCurrentPosition KEYWORD2
+getHome	KEYWORD2
+getCurrentPosition	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords